### PR TITLE
Fix test

### DIFF
--- a/Tests/Unit/Entity/TaskTest.php
+++ b/Tests/Unit/Entity/TaskTest.php
@@ -43,6 +43,7 @@ class TaskTest extends \PHPUnit_Framework_TestCase
 
         $nowDate = new \DateTime();
         $oneDayInterval = new \DateInterval('P1D');
+        $twoDayInterval = new \DateInterval('P2D');
 
         $this->assertFalse($entity->isDueDateExpired());
 
@@ -50,7 +51,8 @@ class TaskTest extends \PHPUnit_Framework_TestCase
         $entity->setDueDate($dateInPast);
         $this->assertTrue($entity->isDueDateExpired());
 
-        $dateInFuture = $nowDate->add($oneDayInterval);
+        $dateInFuture = $nowDate->add($twoDayInterval);
+
         $entity->setDueDate($dateInFuture);
         $this->assertFalse($entity->isDueDateExpired());
     }


### PR DESCRIPTION
Related to https://github.com/orocrm/platform/issues/600


In PHP 7.1 DateTime constructor incorporates microseconds, this generate errors in tests. 
http://php.net/manual/en/migration71.incompatible.php
